### PR TITLE
Remove unused State tab from Web UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,7 @@ Python-based Docker image auto-updater that tracks version-specific tags matchin
 - **Daemon control**: Start/stop background checking with configurable intervals
 - **Update history**: Track all checks with timestamps, applied vs dry-run indication
 - **Activity log**: Real-time log streaming with color-coded severity
-- **REST API**: Full API for integration (`/api/status`, `/api/config`, `/api/check`, etc.)
-- **State display**: View tracked digests and last update timestamps
+- **REST API**: Full API for integration (`/api/status`, `/api/config`, `/api/check`, `/api/state`, etc.)
 
 ## Critical Implementation Details
 - **Docker API**: Direct HTTP requests to Docker socket for registry operations (manifest fetches)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -248,16 +248,6 @@ h1 {
     resize: vertical;
 }
 
-.state-view {
-    font-family: monospace;
-    font-size: 14px;
-    white-space: pre-wrap;
-    background: var(--background);
-    padding: 15px;
-    border-radius: 4px;
-    overflow-x: auto;
-}
-
 .history-list {
     display: grid;
     gap: 8px;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -92,7 +92,6 @@ async function loadStatus() {
 
         // Load other data
         loadConfig();
-        loadState();
         loadHistory();
         loadUpdates();
 
@@ -614,17 +613,6 @@ async function saveConfig() {
     }
 }
 
-// Load current state
-async function loadState() {
-    try {
-        const response = await fetch('/api/state');
-        const state = await response.json();
-        dom.stateView.textContent = JSON.stringify(state, null, 2);
-    } catch (error) {
-        addLog('Failed to load state: ' + error, 'error');
-    }
-}
-
 // Load update history
 async function loadHistory() {
     try {
@@ -766,7 +754,6 @@ document.addEventListener('DOMContentLoaded', () => {
     dom.imageCards = document.getElementById('image-cards');
     dom.addImageBtn = document.getElementById('add-image');
     dom.saveConfigBtn = document.getElementById('save-config');
-    dom.stateView = document.getElementById('state-view');
     dom.historyList = document.getElementById('history-list');
     dom.daemonInterval = document.getElementById('daemon-interval');
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,6 @@
         <div class="tabs">
             <button class="tab-button active" data-tab="updates">Updates</button>
             <button class="tab-button" data-tab="config">Configuration</button>
-            <button class="tab-button" data-tab="state">State</button>
             <button class="tab-button" data-tab="history">History</button>
         </div>
 
@@ -58,13 +57,6 @@
                     <div id="image-cards" class="image-cards-container">
                         <!-- Cards dynamically inserted by JavaScript -->
                     </div>
-                </div>
-            </div>
-
-            <div id="state" class="tab-pane">
-                <h2>Current State</h2>
-                <div id="state-view" class="state-view">
-                    <p>Loading state...</p>
                 </div>
             </div>
 


### PR DESCRIPTION
The State tab always showed empty {} because state is only populated when updates are applied, and dry-run mode (default) never saves state.

- Remove State tab button and pane from HTML
- Remove loadState() function and stateView from JS
- Remove .state-view CSS rule
- Keep /api/state endpoint for API users who may want it