### PR TITLE
Add configurable image retention with keep_versions option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,12 @@ Python-based Docker image auto-updater that tracks version-specific tags matchin
     "auto_update": false,
     "container_name": "calibre",
     "cleanup_old_images": true,
+    "keep_versions": 3,
     "registry": "optional-custom-registry"
   }]
 }
 ```
+- `keep_versions`: Number of image versions to retain when cleanup is enabled (default: 3)
 
 ## Security & Code Quality Improvements
 - **Security fixes**: Fixed command injection, JSON schema validation, file locking, request timeouts

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -623,6 +623,28 @@ h1 {
     justify-content: flex-end;
 }
 
+/* Keep Versions Field */
+.keep-versions-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.keep-versions-group label {
+    margin-bottom: 0;
+    min-width: auto;
+}
+
+.form-input-small {
+    width: 80px;
+}
+
+.field-hint {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
 /* Responsive - Config Cards */
 @media (max-width: 768px) {
     .config-toolbar {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -270,6 +270,14 @@ function createImageCard(config, index, isNew = false) {
                     <span>Cleanup old images</span>
                 </label>
             </div>
+
+            <div class="form-group keep-versions-group">
+                <label>Keep Versions</label>
+                <input type="number" class="form-input form-input-small" name="keep_versions"
+                       value="${config.keep_versions || 3}"
+                       min="1" max="99">
+                <span class="field-hint">Number of image versions to keep when cleanup is enabled</span>
+            </div>
         </div>
     `;
 
@@ -450,6 +458,7 @@ function addNewImage() {
         auto_update: false,
         container_name: '',
         cleanup_old_images: false,
+        keep_versions: 3,
         registry: ''
     };
 
@@ -565,12 +574,14 @@ function collectFormData() {
         const registry = card.querySelector('input[name="registry"]').value.trim();
         const autoUpdate = card.querySelector('input[name="auto_update"]').checked;
         const cleanup = card.querySelector('input[name="cleanup_old_images"]').checked;
+        const keepVersions = parseInt(card.querySelector('input[name="keep_versions"]').value, 10) || 3;
 
         if (baseTag) config.base_tag = baseTag;
         if (containerName) config.container_name = containerName;
         if (registry) config.registry = registry;
         if (autoUpdate) config.auto_update = true;
         if (cleanup) config.cleanup_old_images = true;
+        if (keepVersions !== 3) config.keep_versions = keepVersions;
 
         configs.push(config);
     });


### PR DESCRIPTION
- Add keep_versions config option (default: 3) to specify how many image versions to retain when cleanup_old_images is enabled
- Update _cleanup_old_images to sort images by creation date and keep the N most recent versions instead of removing all old images
- Add keep_versions field to Web UI config card editor
- Dry-run mode now shows which images would be removed

This allows users to maintain a rolling history of image versions for rollback purposes while still cleaning up very old images.