### PR TITLE
v1.4.0: Docker API version negotiation + container update timeout resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -66,12 +66,28 @@ Use the Web UI to add images via **Add from Preset** (19 built-in) or **+ Add Im
     "auto_update": false,
     "cleanup_old_images": true,
     "keep_versions": 3,
-    "registry": "ghcr.io"
+    "registry": "ghcr.io",
+    "stop_timeout": 10,
+    "request_timeout": 60
   }]
 }
 ```
 
 Only `image` and `regex` are required. Containers are auto-detected — no need to specify container names.
+
+### Timeouts
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `stop_timeout` | `10` | Seconds Docker waits after SIGTERM before SIGKILL when stopping the container |
+| `request_timeout` | `60` | Seconds to wait for the Docker daemon to answer a container lifecycle call |
+
+Raise both for containers that are slow to stop, or on slow storage such as a
+NAS. The stop request gets `stop_timeout + request_timeout` seconds in total,
+so the socket cannot expire before the grace period has even elapsed. If the
+daemon does time out, the update is abandoned and retried on the next cycle —
+the container is left running (or restarted if it had already been stopped),
+never half-migrated.
 
 ### Common Patterns
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,13 @@ Only `image` and `regex` are required. Containers are auto-detected — no need 
 
 Raise both for containers that are slow to stop, or on slow storage such as a
 NAS. The stop request gets `stop_timeout + request_timeout` seconds in total,
-so the socket cannot expire before the grace period has even elapsed. If the
-daemon does time out, the update is abandoned and retried on the next cycle —
-the container is left running (or restarted if it had already been stopped),
-never half-migrated.
+so the socket cannot expire before the grace period has even elapsed.
+
+If a request does time out, ium never assumes the worst: the daemon often
+completes the operation after the socket gave up. It inspects the container and
+continues the update if it really did stop, restores the previous container if a
+later step failed, and starts a container that a previous run created but never
+started. A container is never left renamed or half-migrated.
 
 ### Common Patterns
 

--- a/docker_api.py
+++ b/docker_api.py
@@ -121,6 +121,18 @@ class DockerClient:
                 return None
 
             return json.loads(raw)
+        except OSError as e:
+            # Socket-level failure — read timeout, connection refused, EPIPE.
+            # TimeoutError and socket.timeout are both OSError subclasses.
+            #
+            # Surface it as DockerAPIError rather than letting it escape: every
+            # caller already handles DockerAPIError, and _update_container's
+            # rollback depends on it.  A bare OSError slips past those handlers,
+            # which leaves a container stopped and renamed with no rollback.
+            #
+            # Status 0 means "no HTTP response" — the daemon may or may not have
+            # applied the request.
+            raise DockerAPIError(0, f"{method} {url}: {e}") from e
         finally:
             conn.close()
 

--- a/docker_api.py
+++ b/docker_api.py
@@ -191,31 +191,43 @@ class DockerClient:
         """
         return self._request("GET", f"/containers/{name}/json")
 
-    def stop_container(self, name: str, timeout: int = 10) -> None:
-        """Stop a container."""
+    def stop_container(self, name: str, timeout: int = 10,
+                       request_timeout: Optional[int] = None) -> None:
+        """Stop a container.
+
+        *timeout* is Docker's SIGTERM grace period (the ``t`` parameter).
+        *request_timeout* is the socket read budget allowed on top of it,
+        defaulting to 30 s.  The daemon can take considerably longer than the
+        grace period to answer on slow storage, and a read that expires first
+        leaves the caller unable to tell whether the stop was applied.
+        """
+        slack = 30 if request_timeout is None else request_timeout
         self._request(
             "POST", f"/containers/{name}/stop",
             query={"t": str(timeout)},
-            timeout=timeout + 30,
+            timeout=timeout + slack,
         )
 
-    def rename_container(self, id_or_name: str, new_name: str) -> None:
+    def rename_container(self, id_or_name: str, new_name: str,
+                         timeout: int = 30) -> None:
         """Rename a container."""
         self._request("POST", f"/containers/{id_or_name}/rename",
-                       query={"name": new_name})
+                       query={"name": new_name}, timeout=timeout)
 
-    def create_container(self, name: str, config: Dict[str, Any]) -> str:
+    def create_container(self, name: str, config: Dict[str, Any],
+                         timeout: int = 30) -> str:
         """Create a container.  Returns the new container ID."""
         result = self._request(
             "POST", "/containers/create",
             body=config,
             query={"name": name},
+            timeout=timeout,
         )
         return result["Id"]
 
-    def start_container(self, name: str) -> None:
+    def start_container(self, name: str, timeout: int = 30) -> None:
         """Start an existing container."""
-        self._request("POST", f"/containers/{name}/start")
+        self._request("POST", f"/containers/{name}/start", timeout=timeout)
 
     def remove_container(self, name: str, force: bool = False, timeout: int = 30) -> None:
         """Remove a container."""
@@ -224,9 +236,11 @@ class DockerClient:
 
     # ── Network operations ────────────────────────────────────────
 
-    def connect_network(self, network: str, container_id: str) -> None:
+    def connect_network(self, network: str, container_id: str,
+                        timeout: int = 30) -> None:
         """Connect a container to a network."""
         self._request(
             "POST", f"/networks/{network}/connect",
             body={"Container": container_id},
+            timeout=timeout,
         )

--- a/docker_api.py
+++ b/docker_api.py
@@ -29,6 +29,7 @@ def _parse_api_version(value: str) -> tuple:
 
 
 def _format_api_version(parsed: tuple) -> str:
+    """Render (1, 44) back into the "v1.44" form used in request paths."""
     return "v" + ".".join(str(part) for part in parsed)
 
 

--- a/docker_api.py
+++ b/docker_api.py
@@ -15,8 +15,21 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Docker Engine API version — compatible with Docker 20.10+
+# Preferred Docker Engine API version.  Deliberately conservative: 1.41 is the
+# ceiling of Docker 20.10, and every endpoint this client uses exists there.
+# The version actually used is negotiated per daemon (see
+# DockerClient._negotiate_api_version) because Docker 25+ rejects anything below
+# its MinAPIVersion of 1.44, and a hard pin cannot satisfy both ends.
 API_VERSION = "v1.41"
+
+
+def _parse_api_version(value: str) -> tuple:
+    """Parse "1.44" or "v1.44" into (1, 44).  Raises ValueError if malformed."""
+    return tuple(int(part) for part in value.strip().lstrip("vV").split("."))
+
+
+def _format_api_version(parsed: tuple) -> str:
+    return "v" + ".".join(str(part) for part in parsed)
 
 
 class DockerAPIError(Exception):
@@ -45,7 +58,8 @@ class UnixHTTPConnection(http.client.HTTPConnection):
 class DockerClient:
     """Client for the Docker Engine API over Unix socket."""
 
-    def __init__(self, socket_path: Optional[str] = None):
+    def __init__(self, socket_path: Optional[str] = None,
+                 api_version: Optional[str] = None):
         if socket_path is None:
             host = os.environ.get("DOCKER_HOST", "")
             if host:
@@ -53,10 +67,69 @@ class DockerClient:
             else:
                 socket_path = "/var/run/docker.sock"
         self._socket_path = socket_path
+        # None means "negotiate on first use"; an explicit value is trusted.
+        self._api_version = api_version
+
+    @property
+    def api_version(self) -> str:
+        """API version to use, negotiated with the daemon on first access."""
+        if self._api_version is None:
+            self._api_version = self._negotiate_api_version()
+        return self._api_version
+
+    def _negotiate_api_version(self) -> str:
+        """Choose an API version this daemon accepts.
+
+        ``GET /version`` is served on the unversioned path by every Engine and
+        reports ApiVersion (newest supported) and MinAPIVersion (oldest).  We
+        prefer API_VERSION, raise it to the daemon's minimum when that is
+        higher, and lower it to the daemon's maximum when that is lower.
+
+        Any failure falls back to API_VERSION: a daemon we cannot probe is
+        better served by an attempt than by an exception.
+        """
+        try:
+            info = self._request("GET", "/version", timeout=10, versioned=False) or {}
+        except DockerAPIError as e:
+            logger.warning(
+                f"Could not probe Docker API version ({e.message}); "
+                f"falling back to {API_VERSION}"
+            )
+            return API_VERSION
+
+        server_max = info.get("ApiVersion") or info.get("APIVersion")
+        server_min = info.get("MinAPIVersion") or info.get("MinApiVersion")
+
+        chosen = _parse_api_version(API_VERSION)
+        try:
+            if server_min:
+                minimum = _parse_api_version(server_min)
+                if minimum > chosen:
+                    chosen = minimum
+            if server_max:
+                maximum = _parse_api_version(server_max)
+                if maximum < chosen:
+                    chosen = maximum
+        except (ValueError, AttributeError):
+            logger.warning(
+                f"Unparseable Docker API version in /version response "
+                f"(ApiVersion={server_max!r}, MinAPIVersion={server_min!r}); "
+                f"falling back to {API_VERSION}"
+            )
+            return API_VERSION
+
+        negotiated = _format_api_version(chosen)
+        if negotiated != API_VERSION:
+            logger.info(
+                f"Negotiated Docker API version {negotiated} "
+                f"(daemon supports {server_min}-{server_max})"
+            )
+        return negotiated
 
     def _request(self, method: str, path: str, body: Any = None,
                  query: Optional[Dict[str, str]] = None,
-                 timeout: int = 30, stream: bool = False) -> Any:
+                 timeout: int = 30, stream: bool = False,
+                 versioned: bool = True) -> Any:
         """Send an HTTP request to the Docker Engine API.
 
         Creates a fresh connection per call (Docker socket is local so
@@ -66,7 +139,9 @@ class DockerClient:
         response body is consumed line-by-line and the last status JSON
         object is returned (used for ``POST /images/create``).
         """
-        url = f"/{API_VERSION}{path}"
+        # versioned=False is used by the negotiation probe itself, which must
+        # not carry a version prefix (and must not recurse into the property).
+        url = f"/{self.api_version}{path}" if versioned else path
         if query:
             url += "?" + urllib.parse.urlencode(query)
 

--- a/ium.py
+++ b/ium.py
@@ -59,7 +59,8 @@ DEFAULT_BASE_TAG = "latest"
 # the old 40 s stop budget and left the container down (2026-07-29 incident).
 DEFAULT_STOP_TIMEOUT = 10
 DEFAULT_REQUEST_TIMEOUT = 60
-REQUEST_TIMEOUT = 30
+# Registry (HTTPS) request timeout — unrelated to the Docker socket budget above.
+REGISTRY_REQUEST_TIMEOUT = 30
 MANIFEST_ACCEPT_HEADER = (
     "application/vnd.docker.distribution.manifest.list.v2+json,"
     "application/vnd.docker.distribution.manifest.v2+json,"
@@ -329,7 +330,7 @@ class DockerImageUpdater:
         """HTTP request with retry on transient failures (connection errors, 5xx)."""
         max_retries = 3
         backoff = 2
-        kwargs.setdefault('timeout', REQUEST_TIMEOUT)
+        kwargs.setdefault('timeout', REGISTRY_REQUEST_TIMEOUT)
         last_exception: Optional[Exception] = None
         for attempt in range(max_retries + 1):
             try:

--- a/ium.py
+++ b/ium.py
@@ -7,7 +7,7 @@ This script monitors Docker images for updates by comparing a base tag
 tags that match user-defined regex patterns.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 import json
 import re
@@ -60,12 +60,13 @@ DEFAULT_BASE_TAG = "latest"
 DEFAULT_STOP_TIMEOUT = 10
 DEFAULT_REQUEST_TIMEOUT = 60
 
+# Registry (HTTPS) request timeout — unrelated to the Docker socket budget above.
+REGISTRY_REQUEST_TIMEOUT = 30
+
 # Container states that mean "not running", so an update may safely continue
 # after a stop request failed.  'paused' is deliberately excluded: a paused
 # container still holds its processes.
 STOPPED_STATUSES = frozenset({'exited', 'created', 'dead'})
-# Registry (HTTPS) request timeout — unrelated to the Docker socket budget above.
-REGISTRY_REQUEST_TIMEOUT = 30
 MANIFEST_ACCEPT_HEADER = (
     "application/vnd.docker.distribution.manifest.list.v2+json,"
     "application/vnd.docker.distribution.manifest.v2+json,"

--- a/ium.py
+++ b/ium.py
@@ -51,6 +51,14 @@ DEFAULT_REGISTRY = "registry-1.docker.io"
 DEFAULT_AUTH_URL = "https://auth.docker.io/token"
 DEFAULT_NAMESPACE = "library"
 DEFAULT_BASE_TAG = "latest"
+
+# Container-update timeouts, overridable per image in config.json.
+# DEFAULT_STOP_TIMEOUT is Docker's SIGTERM grace period; DEFAULT_REQUEST_TIMEOUT
+# is the socket read budget for lifecycle calls.  60 s rather than the 30 s
+# http.client default: stopping a large container on NAS-grade storage overran
+# the old 40 s stop budget and left the container down (2026-07-29 incident).
+DEFAULT_STOP_TIMEOUT = 10
+DEFAULT_REQUEST_TIMEOUT = 60
 REQUEST_TIMEOUT = 30
 MANIFEST_ACCEPT_HEADER = (
     "application/vnd.docker.distribution.manifest.list.v2+json,"
@@ -99,7 +107,9 @@ CONFIG_SCHEMA = {
                     "auto_update": {"type": "boolean"},
                     "registry": {"type": "string"},
                     "cleanup_old_images": {"type": "boolean"},
-                    "keep_versions": {"type": "integer", "minimum": 1}
+                    "keep_versions": {"type": "integer", "minimum": 1},
+                    "stop_timeout": {"type": "integer", "minimum": 1},
+                    "request_timeout": {"type": "integer", "minimum": 1}
                 },
                 "required": ["image", "regex"]
             }
@@ -1065,7 +1075,9 @@ class DockerImageUpdater:
             return None
 
     def _update_container(self, container_name: str, image: str, tag: str,
-                          registry: Optional[str] = None) -> bool:
+                          registry: Optional[str] = None,
+                          stop_timeout: int = DEFAULT_STOP_TIMEOUT,
+                          request_timeout: int = DEFAULT_REQUEST_TIMEOUT) -> bool:
         """
         Update a running container with a new image.
 
@@ -1074,6 +1086,8 @@ class DockerImageUpdater:
             image: Image name
             tag: Tag to use
             registry: Optional registry override (e.g. 'ghcr.io')
+            stop_timeout: SIGTERM grace period passed to Docker when stopping
+            request_timeout: Socket read budget for the Docker lifecycle calls
 
         Returns:
             True if successful, False otherwise
@@ -1114,7 +1128,7 @@ class DockerImageUpdater:
                 f"'{status or 'unknown'}' — starting it (interrupted update)"
             )
             try:
-                self.docker.start_container(container_name)
+                self.docker.start_container(container_name, timeout=request_timeout)
             except DockerAPIError as e:
                 self.logger.error(
                     f"Could not start {container_name}: {e.message}"
@@ -1130,30 +1144,36 @@ class DockerImageUpdater:
 
             # Stop the container
             self.logger.info(f"Stopping container {container_name}...")
-            self.docker.stop_container(container_name)
+            self.docker.stop_container(container_name, timeout=stop_timeout,
+                                      request_timeout=request_timeout)
 
             # Rename old container as backup
             backup_name = f"{container_name}_backup_{int(time.time())}"
             self.logger.info(f"Renaming old container to {backup_name}")
-            self.docker.rename_container(container_name, backup_name)
+            self.docker.rename_container(container_name, backup_name,
+                                        timeout=request_timeout)
 
             # Create and start new container
             self.logger.info(f"Creating new container {container_name}...")
             try:
-                container_id = self.docker.create_container(container_name, create_config)
-                self.docker.start_container(container_id)
+                container_id = self.docker.create_container(
+                    container_name, create_config, timeout=request_timeout)
+                self.docker.start_container(container_id, timeout=request_timeout)
 
                 # Connect to additional networks
                 for network in extra_networks:
-                    self.docker.connect_network(network, container_id)
+                    self.docker.connect_network(network, container_id,
+                                                timeout=request_timeout)
 
             except DockerAPIError as e:
                 # Rollback on failure
                 self.logger.error(f"Failed to create new container: {e.message}")
                 self.logger.info("Rolling back...")
                 try:
-                    self.docker.rename_container(backup_name, container_name)
-                    self.docker.start_container(container_name)
+                    self.docker.rename_container(backup_name, container_name,
+                                                timeout=request_timeout)
+                    self.docker.start_container(container_name,
+                                               timeout=request_timeout)
                 except DockerAPIError as rb_err:
                     # Rename failed — the new container likely took the name already
                     # (e.g. it was created and started before an extra-network connect
@@ -1186,7 +1206,9 @@ class DockerImageUpdater:
             return False
 
     def _update_containers(self, container_names: List[str], image: str, tag: str,
-                           registry: Optional[str] = None) -> Dict[str, bool]:
+                           registry: Optional[str] = None,
+                           stop_timeout: int = DEFAULT_STOP_TIMEOUT,
+                           request_timeout: int = DEFAULT_REQUEST_TIMEOUT) -> Dict[str, bool]:
         """Update multiple containers to a new image tag.
 
         Args:
@@ -1194,6 +1216,8 @@ class DockerImageUpdater:
             image: Base image name
             tag: Target tag to update to
             registry: Optional registry override (e.g. 'ghcr.io')
+            stop_timeout: SIGTERM grace period passed to Docker when stopping
+            request_timeout: Socket read budget for the Docker lifecycle calls
 
         Returns:
             Dict mapping container_name -> success boolean
@@ -1201,7 +1225,10 @@ class DockerImageUpdater:
         results = {}
         for container_name in container_names:
             self.logger.info(f"Updating container {container_name} to {image}:{tag}")
-            success = self._update_container(container_name, image, tag, registry)
+            success = self._update_container(
+                container_name, image, tag, registry,
+                stop_timeout=stop_timeout, request_timeout=request_timeout,
+            )
             results[container_name] = success
 
         # Log summary
@@ -1454,6 +1481,8 @@ class DockerImageUpdater:
             registry = image_config.get('registry')
             cleanup = image_config.get('cleanup_old_images', False)
             keep_versions = image_config.get('keep_versions', 3)
+            stop_timeout = image_config.get('stop_timeout', DEFAULT_STOP_TIMEOUT)
+            request_timeout = image_config.get('request_timeout', DEFAULT_REQUEST_TIMEOUT)
 
             self.logger.info(f"Checking {image}:{base_tag}...")
 
@@ -1550,7 +1579,11 @@ class DockerImageUpdater:
                                 # Update all discovered containers
                                 container_names = [c['name'] for c in containers]
                                 self.logger.info(f"Found {len(containers)} container(s) using {image}: {', '.join(container_names)}")
-                                update_results = self._update_containers(container_names, image, matching_tag, registry)
+                                update_results = self._update_containers(
+                                    container_names, image, matching_tag, registry,
+                                    stop_timeout=stop_timeout,
+                                    request_timeout=request_timeout,
+                                )
 
                                 # Only mark success if ALL containers updated;
                                 # partial failure leaves state unchanged so the
@@ -1616,7 +1649,11 @@ class DockerImageUpdater:
                             if containers:
                                 container_names = [c['name'] for c in containers]
                                 self.logger.info(f"Found {len(containers)} container(s) using {image}: {', '.join(container_names)}")
-                                update_results = self._update_containers(container_names, image, matching_tag, registry)
+                                update_results = self._update_containers(
+                                    container_names, image, matching_tag, registry,
+                                    stop_timeout=stop_timeout,
+                                    request_timeout=request_timeout,
+                                )
                                 update_ok = any(update_results.values()) if update_results else True
                             else:
                                 self.logger.info(f"No containers found for {image}, image updated only")

--- a/ium.py
+++ b/ium.py
@@ -59,6 +59,11 @@ DEFAULT_BASE_TAG = "latest"
 # the old 40 s stop budget and left the container down (2026-07-29 incident).
 DEFAULT_STOP_TIMEOUT = 10
 DEFAULT_REQUEST_TIMEOUT = 60
+
+# Container states that mean "not running", so an update may safely continue
+# after a stop request failed.  'paused' is deliberately excluded: a paused
+# container still holds its processes.
+STOPPED_STATUSES = frozenset({'exited', 'created', 'dead'})
 # Registry (HTTPS) request timeout — unrelated to the Docker socket budget above.
 REGISTRY_REQUEST_TIMEOUT = 30
 MANIFEST_ACCEPT_HEADER = (
@@ -1145,8 +1150,30 @@ class DockerImageUpdater:
 
             # Stop the container
             self.logger.info(f"Stopping container {container_name}...")
-            self.docker.stop_container(container_name, timeout=stop_timeout,
-                                      request_timeout=request_timeout)
+            try:
+                self.docker.stop_container(container_name, timeout=stop_timeout,
+                                          request_timeout=request_timeout)
+            except DockerAPIError as stop_err:
+                # A failed stop request does not prove the stop did not happen.
+                # The daemon can finish stopping a heavy container after our
+                # socket budget expires, which is exactly what stranded a
+                # container on 2026-07-29.  Inspect before giving up.
+                post_stop = self._get_container_config(container_name)
+                status = ((post_stop or {}).get('State') or {}).get('Status', '')
+                if status in STOPPED_STATUSES:
+                    self.logger.warning(
+                        f"Stop request for {container_name} failed "
+                        f"({stop_err.message}) but the container is '{status}' "
+                        f"— continuing with the update"
+                    )
+                else:
+                    detail = f"still '{status}'" if status else "state unknown"
+                    self.logger.error(
+                        f"Could not stop {container_name} ({stop_err.message}); "
+                        f"{detail} — aborting update to avoid renaming a live "
+                        f"container"
+                    )
+                    return False
 
             # Rename old container as backup
             backup_name = f"{container_name}_backup_{int(time.time())}"

--- a/ium.py
+++ b/ium.py
@@ -1099,7 +1099,27 @@ class DockerImageUpdater:
         # Skip if already running the target image (e.g. retry after partial failure)
         current_image = container_info.get('Config', {}).get('Image', '')
         if current_image == full_image:
-            self.logger.info(f"Container {container_name} already running {full_image}, skipping")
+            status = (container_info.get('State') or {}).get('Status', '')
+            if status == 'running':
+                self.logger.info(f"Container {container_name} already running {full_image}, skipping")
+                return True
+
+            # On the target image but not running: a previous update was
+            # interrupted after create_container (e.g. its response timed out).
+            # Reporting success here would leave the container down forever,
+            # since every later cycle takes this same short-circuit.  Starting
+            # is idempotent — Docker answers 304 if it is already up.
+            self.logger.warning(
+                f"Container {container_name} is on {full_image} but status is "
+                f"'{status or 'unknown'}' — starting it (interrupted update)"
+            )
+            try:
+                self.docker.start_container(container_name)
+            except DockerAPIError as e:
+                self.logger.error(
+                    f"Could not start {container_name}: {e.message}"
+                )
+                return False
             return True
 
         try:

--- a/ium.py
+++ b/ium.py
@@ -936,6 +936,24 @@ class DockerImageUpdater:
             )
             return None
 
+    def _container_exists(self, container_name: str) -> Optional[bool]:
+        """Whether a container exists, as far as the daemon will say.
+
+        Returns True/False when the daemon answers, and None when it could not
+        be reached — an unreachable daemon must not be mistaken for a 404, since
+        callers use this to decide whether a half-applied operation landed.
+        """
+        try:
+            self.docker.inspect_container(container_name)
+            return True
+        except DockerAPIError as e:
+            if e.status == 404:
+                return False
+            self.logger.warning(
+                f"Could not determine whether '{container_name}' exists: {e.message}"
+            )
+            return None
+
     def _get_containers_for_image(self, image: str) -> List[Dict[str, str]]:
         """Get all containers (running or stopped) using a specific image.
 
@@ -1179,8 +1197,48 @@ class DockerImageUpdater:
             # Rename old container as backup
             backup_name = f"{container_name}_backup_{int(time.time())}"
             self.logger.info(f"Renaming old container to {backup_name}")
-            self.docker.rename_container(container_name, backup_name,
-                                        timeout=request_timeout)
+            try:
+                self.docker.rename_container(container_name, backup_name,
+                                            timeout=request_timeout)
+            except DockerAPIError as rename_err:
+                # The most dangerous call in the update to lose the answer to:
+                # the container is already stopped, and its identity is now
+                # ambiguous.  Creating a replacement blindly could collide with
+                # a container still holding the name, while aborting blindly
+                # could abandon it under the backup name forever.  Ask both.
+                renamed = self._container_exists(backup_name)
+                original = self._container_exists(container_name)
+
+                if renamed is True and original is False:
+                    self.logger.warning(
+                        f"Rename request failed ({rename_err.message}) but "
+                        f"{container_name} is now {backup_name} — continuing "
+                        f"with the update"
+                    )
+                elif original is True:
+                    self.logger.error(
+                        f"Could not rename {container_name} "
+                        f"({rename_err.message}); restarting it and aborting "
+                        f"the update"
+                    )
+                    try:
+                        self.docker.start_container(container_name,
+                                                   timeout=request_timeout)
+                    except DockerAPIError as restart_err:
+                        self.logger.error(
+                            f"Could not restart {container_name} after the "
+                            f"failed rename: {restart_err.message} — start it "
+                            f"manually"
+                        )
+                    return False
+                else:
+                    self.logger.error(
+                        f"Could not rename {container_name} "
+                        f"({rename_err.message}) and cannot determine whether "
+                        f"the rename was applied — aborting without creating a "
+                        f"replacement; check for {backup_name} manually"
+                    )
+                    return False
 
             # Create and start new container
             self.logger.info(f"Creating new container {container_name}...")

--- a/tests/fake_docker.py
+++ b/tests/fake_docker.py
@@ -1,0 +1,49 @@
+"""A fake Docker socket for exercising DockerClient without a daemon.
+
+Patches docker_api.UnixHTTPConnection, so the real DockerClient._request runs:
+URL construction, status handling and error translation are all under test.
+The handler receives (method, url, body) and either returns a FakeResponse or
+raises — raising from getresponse() reproduces a read timeout in the same place
+the production traceback showed one.
+"""
+
+from unittest.mock import patch
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: bytes = b""):
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class FakeConn:
+    def __init__(self, handler, calls):
+        self._handler = handler
+        self._calls = calls
+        self._pending = None
+
+    def request(self, method, url, body=None, headers=None):
+        self._pending = (method, url, body)
+        self._calls.append((method, url))
+
+    def getresponse(self):
+        return self._handler(*self._pending)
+
+    def close(self):
+        pass
+
+
+def fake_socket(handler):
+    """Return (patcher, calls) — use the patcher as a context manager.
+
+    *calls* accumulates (method, url) tuples for every request issued.
+    """
+    calls: list[tuple[str, str]] = []
+    patcher = patch(
+        "docker_api.UnixHTTPConnection",
+        lambda socket_path, timeout=30: FakeConn(handler, calls),
+    )
+    return patcher, calls

--- a/tests/test_api_version_negotiation.py
+++ b/tests/test_api_version_negotiation.py
@@ -1,0 +1,150 @@
+"""Docker Engine API version negotiation.
+
+Regression coverage for issue #25: API_VERSION was pinned to v1.41, but Docker
+Engine 25+ refuses anything below 1.44 --
+
+    Docker API error 400: client version 1.41 is too old.
+    Minimum supported API version is 1.44
+
+Every request failed, so container discovery returned nothing and updates were
+reported against "unknown". Bumping the pin would instead break Docker 20.10,
+whose ceiling is 1.41, so the version has to be negotiated per daemon.
+
+GET /version is served on the unversioned path by every Engine and reports both
+ApiVersion (newest supported) and MinAPIVersion (oldest supported).
+"""
+
+import json
+import pytest
+
+from docker_api import API_VERSION, DockerAPIError, DockerClient
+from tests.fake_docker import FakeResponse, fake_socket
+
+
+def version_payload(api_version: str, min_api_version: str) -> bytes:
+    return json.dumps({
+        "Version": "29.1.3",
+        "ApiVersion": api_version,
+        "MinAPIVersion": min_api_version,
+    }).encode()
+
+
+def handler_for(api_version: str, min_api_version: str):
+    """Answer /version, and 200 with an empty object for anything else."""
+    def handler(method, url, body):
+        if url == "/version":
+            return FakeResponse(200, version_payload(api_version, min_api_version))
+        return FakeResponse(200, b"{}")
+    return handler
+
+
+def request_paths(calls):
+    """Paths of the non-negotiation requests."""
+    return [u for _, u in calls if u != "/version"]
+
+
+class TestNegotiation:
+
+    def test_uses_server_minimum_when_pin_is_too_old(self):
+        """Docker 29: min 1.44 -- the old v1.41 pin must be raised to it."""
+        patcher, calls = fake_socket(handler_for("1.52", "1.44"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        assert request_paths(calls) == ["/v1.44/containers/json"]
+
+    def test_uses_preferred_version_when_daemon_allows_it(self):
+        """A daemon spanning our preferred version must get exactly that."""
+        patcher, calls = fake_socket(handler_for("1.51", "1.24"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        assert request_paths(calls) == [f"/{API_VERSION}/containers/json"]
+
+    def test_caps_at_server_maximum_when_daemon_is_older(self):
+        """Docker 19.03: ceiling 1.40, below our preferred 1.41."""
+        patcher, calls = fake_socket(handler_for("1.40", "1.12"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        assert request_paths(calls) == ["/v1.40/containers/json"]
+
+    def test_version_probe_is_not_itself_versioned(self):
+        """A versioned probe would 400 on the very daemons we are probing."""
+        patcher, calls = fake_socket(handler_for("1.52", "1.44"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        probes = [u for _, u in calls if "/version" in u]
+        assert probes == ["/version"], f"probe must be unversioned, got {probes}"
+
+    def test_negotiates_only_once_per_client(self):
+        patcher, calls = fake_socket(handler_for("1.52", "1.44"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+            client.list_containers()
+            client.inspect_container("sonarr")
+
+        probes = [u for _, u in calls if u == "/version"]
+        assert len(probes) == 1, f"negotiated {len(probes)} times, expected once"
+
+    def test_falls_back_to_pinned_version_when_probe_fails(self):
+        """An unreachable probe must not stop the client from trying."""
+        def handler(method, url, body):
+            if url == "/version":
+                raise TimeoutError("timed out")
+            return FakeResponse(200, b"{}")
+
+        patcher, calls = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        assert request_paths(calls) == [f"/{API_VERSION}/containers/json"]
+
+    def test_malformed_probe_response_falls_back(self):
+        """Garbage in ApiVersion must not crash the client."""
+        def handler(method, url, body):
+            if url == "/version":
+                return FakeResponse(200, json.dumps(
+                    {"ApiVersion": "banana", "MinAPIVersion": "also-banana"}
+                ).encode())
+            return FakeResponse(200, b"{}")
+
+        patcher, calls = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            client.list_containers()
+
+        assert request_paths(calls) == [f"/{API_VERSION}/containers/json"]
+
+    def test_explicit_version_skips_negotiation(self):
+        """An explicit override must be honoured without probing."""
+        patcher, calls = fake_socket(handler_for("1.52", "1.44"))
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock", api_version="v1.47")
+            client.list_containers()
+
+        assert [u for _, u in calls] == ["/v1.47/containers/json"]
+
+
+class TestNegotiationErrorsStillSurface:
+
+    def test_real_api_errors_are_not_masked_by_negotiation(self):
+        """A 404 on the actual call must still raise, post-negotiation."""
+        def handler(method, url, body):
+            if url == "/version":
+                return FakeResponse(200, version_payload("1.52", "1.44"))
+            return FakeResponse(404, json.dumps({"message": "No such container"}).encode())
+
+        patcher, _ = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            with pytest.raises(DockerAPIError) as exc:
+                client.inspect_container("nope")
+            assert exc.value.status == 404

--- a/tests/test_configurable_timeouts.py
+++ b/tests/test_configurable_timeouts.py
@@ -1,0 +1,204 @@
+"""Per-image timeout configuration.
+
+The 2026-07-29 incident timed out stopping a heavy container: the socket
+budget for POST /containers/{name}/stop was hardcoded at grace + 30s = 40s,
+and Synology needed longer.  Two knobs are configurable per image:
+
+  stop_timeout    -- Docker's SIGTERM grace period (the `t` query param)
+  request_timeout -- socket read budget for container lifecycle calls
+
+Both must reach the Docker client, not just the config schema.
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+from jsonschema import ValidationError, validate
+
+from docker_api import DockerClient
+from ium import CONFIG_SCHEMA, DockerImageUpdater
+
+
+@pytest.fixture
+def updater(tmp_path):
+    config_file = tmp_path / "config.json"
+    state_file = tmp_path / "state.json"
+    config_file.write_text(json.dumps({
+        "images": [{
+            "image": "linuxserver/calibre",
+            "regex": r"^v[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+            "base_tag": "latest",
+            "auto_update": True,
+            "stop_timeout": 60,
+            "request_timeout": 180,
+        }]
+    }))
+    state_file.write_text("{}")
+    return DockerImageUpdater(str(config_file), str(state_file))
+
+
+CONTAINER_INFO = {
+    "Id": "abc123" * 10,
+    "Config": {
+        "Image": "linuxserver/calibre:v9.10.0-ls400",
+        "Hostname": "abc123abc1",
+        "User": "", "WorkingDir": "",
+        "Env": ["PATH=/usr/bin:/bin"],
+        "Cmd": None, "Labels": {},
+    },
+    "HostConfig": {
+        "RestartPolicy": {"Name": "", "MaximumRetryCount": 0},
+        "NetworkMode": "default",
+        "PortBindings": None,
+        "Privileged": False, "CapAdd": None, "CapDrop": None,
+        "Devices": None, "Memory": 0, "CpuShares": 0,
+        "CpuQuota": 0, "SecurityOpt": None, "Runtime": "",
+    },
+    "Mounts": [],
+    "NetworkSettings": {"Networks": {}},
+    "State": {"Status": "running"},
+}
+
+
+class TestConfigSchema:
+
+    def test_schema_accepts_timeout_keys(self):
+        config = {"images": [{
+            "image": "linuxserver/calibre",
+            "regex": r"^v.*$",
+            "stop_timeout": 60,
+            "request_timeout": 180,
+        }]}
+        validate(instance=config, schema=CONFIG_SCHEMA)
+
+    @pytest.mark.parametrize("key", ["stop_timeout", "request_timeout"])
+    @pytest.mark.parametrize("bad_value", ["60", 0, -5, 1.5])
+    def test_schema_rejects_invalid_timeouts(self, key, bad_value):
+        """Typos and nonsense values must fail validation, not reach Docker."""
+        config = {"images": [{
+            "image": "linuxserver/calibre",
+            "regex": r"^v.*$",
+            key: bad_value,
+        }]}
+        with pytest.raises(ValidationError):
+            validate(instance=config, schema=CONFIG_SCHEMA)
+
+
+class TestDockerClientTimeouts:
+    """stop_container must separate the grace period from the socket budget."""
+
+    def test_stop_socket_budget_is_grace_plus_request_timeout(self):
+        captured = {}
+
+        def fake_request(method, path, body=None, query=None, timeout=30, stream=False):
+            captured['query'] = query
+            captured['timeout'] = timeout
+
+        client = DockerClient(socket_path="/nonexistent.sock")
+        with patch.object(client, '_request', side_effect=fake_request):
+            client.stop_container("calibre", timeout=60, request_timeout=180)
+
+        assert captured['query'] == {"t": "60"}, "grace period must reach Docker"
+        assert captured['timeout'] == 240, (
+            "socket budget must be grace + request_timeout so a slow daemon "
+            "cannot expire the read before the grace period elapses"
+        )
+
+    def test_stop_socket_budget_defaults_preserve_old_behaviour(self):
+        captured = {}
+
+        def fake_request(method, path, body=None, query=None, timeout=30, stream=False):
+            captured['timeout'] = timeout
+
+        client = DockerClient(socket_path="/nonexistent.sock")
+        with patch.object(client, '_request', side_effect=fake_request):
+            client.stop_container("calibre")
+
+        assert captured['timeout'] == 40, "default stays grace(10) + 30"
+
+
+class TestTimeoutsReachDockerClient:
+    """The configured values must be applied to the actual Docker calls."""
+
+    def test_update_container_applies_both_timeouts(self, updater):
+        with patch.object(updater, '_get_container_config', return_value=CONTAINER_INFO), \
+             patch.object(updater.docker, 'stop_container') as mock_stop, \
+             patch.object(updater.docker, 'rename_container'), \
+             patch.object(updater.docker, 'create_container', return_value='new123') as mock_create, \
+             patch.object(updater.docker, 'start_container') as mock_start, \
+             patch.object(updater.docker, 'remove_container'):
+
+            result = updater._update_container(
+                'calibre', 'linuxserver/calibre', 'v9.11.0-ls414',
+                stop_timeout=60, request_timeout=180,
+            )
+
+        assert result is True
+        assert mock_stop.call_args.kwargs.get('timeout') == 60
+        assert mock_stop.call_args.kwargs.get('request_timeout') == 180
+        assert mock_create.call_args.kwargs.get('timeout') == 180
+        assert mock_start.call_args.kwargs.get('timeout') == 180
+
+    def test_update_containers_forwards_timeouts(self, updater):
+        with patch.object(updater, '_update_container', return_value=True) as mock_one:
+            updater._update_containers(
+                ['calibre'], 'linuxserver/calibre', 'v9.11.0-ls414',
+                stop_timeout=60, request_timeout=180,
+            )
+
+        assert mock_one.call_args.kwargs.get('stop_timeout') == 60
+        assert mock_one.call_args.kwargs.get('request_timeout') == 180
+
+
+class TestConfigValuesReachUpdate:
+    """Values in config.json must flow through check_and_update."""
+
+    def test_configured_timeouts_are_passed_through(self, updater):
+        containers = [{
+            'name': 'calibre', 'id': 'abc123', 'state': 'running',
+            'image_ref': 'linuxserver/calibre:v9.10.0-ls400',
+        }]
+
+        with patch.object(updater, '_get_containers_for_image', return_value=containers), \
+             patch.object(updater, 'find_matching_tag',
+                          return_value=('v9.11.0-ls414', 'sha256:newdigest')), \
+             patch.object(updater, '_get_container_current_tag', return_value='v9.10.0-ls400'), \
+             patch.object(updater, '_pull_image', return_value=True), \
+             patch.object(updater, '_update_containers',
+                          return_value={'calibre': True}) as mock_update:
+
+            updater.check_and_update()
+
+        assert mock_update.call_args.kwargs.get('stop_timeout') == 60
+        assert mock_update.call_args.kwargs.get('request_timeout') == 180
+
+    def test_defaults_used_when_config_omits_them(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        state_file = tmp_path / "state.json"
+        config_file.write_text(json.dumps({
+            "images": [{
+                "image": "linuxserver/calibre",
+                "regex": r"^v[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+                "auto_update": True,
+            }]
+        }))
+        state_file.write_text("{}")
+        upd = DockerImageUpdater(str(config_file), str(state_file))
+
+        containers = [{
+            'name': 'calibre', 'id': 'abc123', 'state': 'running',
+            'image_ref': 'linuxserver/calibre:v9.10.0-ls400',
+        }]
+
+        with patch.object(upd, '_get_containers_for_image', return_value=containers), \
+             patch.object(upd, 'find_matching_tag',
+                          return_value=('v9.11.0-ls414', 'sha256:newdigest')), \
+             patch.object(upd, '_get_container_current_tag', return_value='v9.10.0-ls400'), \
+             patch.object(upd, '_pull_image', return_value=True), \
+             patch.object(upd, '_update_containers',
+                          return_value={'calibre': True}) as mock_update:
+
+            upd.check_and_update()
+
+        assert mock_update.call_args.kwargs.get('stop_timeout') == 10
+        assert mock_update.call_args.kwargs.get('request_timeout') == 60

--- a/tests/test_interrupted_update_recovery.py
+++ b/tests/test_interrupted_update_recovery.py
@@ -12,7 +12,7 @@ import pytest
 from unittest.mock import patch
 
 from docker_api import DockerAPIError
-from ium import DockerImageUpdater
+from ium import DEFAULT_REQUEST_TIMEOUT, DockerImageUpdater
 
 
 TARGET_TAG = "4.0.16.2944-ls299"
@@ -52,7 +52,7 @@ class TestInterruptedUpdateRecovery:
 
             result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
 
-            mock_start.assert_called_once_with('sonarr')
+            mock_start.assert_called_once_with('sonarr', timeout=DEFAULT_REQUEST_TIMEOUT)
             mock_stop.assert_not_called()
             assert result is True
 
@@ -63,7 +63,7 @@ class TestInterruptedUpdateRecovery:
 
             result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
 
-            mock_start.assert_called_once_with('sonarr')
+            mock_start.assert_called_once_with('sonarr', timeout=DEFAULT_REQUEST_TIMEOUT)
             assert result is True
 
     def test_running_container_on_target_image_is_left_alone(self, updater):

--- a/tests/test_interrupted_update_recovery.py
+++ b/tests/test_interrupted_update_recovery.py
@@ -1,0 +1,91 @@
+"""Recovery when a previous update was interrupted after container create.
+
+If create_container succeeded on the daemon but its response timed out, the
+next cycle finds a container already carrying the target image that was never
+started.  The retry short-circuit must not report success for it — it checked
+the image but not the state, so a permanently-down container was reported as
+"already running".
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from docker_api import DockerAPIError
+from ium import DockerImageUpdater
+
+
+TARGET_TAG = "4.0.16.2944-ls299"
+TARGET_IMAGE = f"linuxserver/sonarr:{TARGET_TAG}"
+
+
+@pytest.fixture
+def updater(tmp_path):
+    config_file = tmp_path / "config.json"
+    state_file = tmp_path / "state.json"
+    config_file.write_text(json.dumps({
+        "images": [{
+            "image": "linuxserver/sonarr",
+            "regex": r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+            "base_tag": "latest",
+            "auto_update": True,
+        }]
+    }))
+    state_file.write_text("{}")
+    return DockerImageUpdater(str(config_file), str(state_file))
+
+
+def _info(status: str) -> dict:
+    return {
+        "Config": {"Image": TARGET_IMAGE},
+        "State": {"Status": status},
+    }
+
+
+class TestInterruptedUpdateRecovery:
+
+    def test_container_created_but_not_started_is_started(self, updater):
+        """A 'created' container on the target image must be started."""
+        with patch.object(updater, '_get_container_config', return_value=_info('created')), \
+             patch.object(updater.docker, 'start_container') as mock_start, \
+             patch.object(updater.docker, 'stop_container') as mock_stop:
+
+            result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
+
+            mock_start.assert_called_once_with('sonarr')
+            mock_stop.assert_not_called()
+            assert result is True
+
+    def test_exited_container_on_target_image_is_started(self, updater):
+        """An 'exited' container on the target image must be started."""
+        with patch.object(updater, '_get_container_config', return_value=_info('exited')), \
+             patch.object(updater.docker, 'start_container') as mock_start:
+
+            result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
+
+            mock_start.assert_called_once_with('sonarr')
+            assert result is True
+
+    def test_running_container_on_target_image_is_left_alone(self, updater):
+        """The existing skip path must not touch a healthy container."""
+        with patch.object(updater, '_get_container_config', return_value=_info('running')), \
+             patch.object(updater.docker, 'start_container') as mock_start, \
+             patch.object(updater.docker, 'stop_container') as mock_stop:
+
+            result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
+
+            mock_start.assert_not_called()
+            mock_stop.assert_not_called()
+            assert result is True
+
+    def test_failure_to_start_reports_failure(self, updater):
+        """If the container cannot be started, do not claim success."""
+        with patch.object(updater, '_get_container_config', return_value=_info('created')), \
+             patch.object(updater.docker, 'start_container',
+                          side_effect=DockerAPIError(0, "POST /start: timed out")):
+
+            result = updater._update_container('sonarr', 'linuxserver/sonarr', TARGET_TAG)
+
+            assert result is False, (
+                "a container that could not be started must not be reported as updated"
+            )

--- a/tests/test_multi_container_update.py
+++ b/tests/test_multi_container_update.py
@@ -3,7 +3,7 @@
 import json
 import pytest
 from unittest.mock import Mock, patch, call
-from ium import DockerImageUpdater
+from ium import DEFAULT_REQUEST_TIMEOUT, DEFAULT_STOP_TIMEOUT, DockerImageUpdater
 
 
 @pytest.fixture
@@ -51,7 +51,9 @@ class TestMultiContainerUpdate:
                 ['sonarr-hd', 'sonarr-4k'],
                 'linuxserver/sonarr',
                 '4.0.16.2944-ls299',
-                None
+                None,
+                stop_timeout=DEFAULT_STOP_TIMEOUT,
+                request_timeout=DEFAULT_REQUEST_TIMEOUT,
             )
 
             # Verify update was detected

--- a/tests/test_multi_container_update.py
+++ b/tests/test_multi_container_update.py
@@ -196,6 +196,7 @@ class TestSkipAlreadyUpdated:
         """A container already running the target image is skipped (returns True)."""
         container_info = {
             'Config': {'Image': 'linuxserver/sonarr:4.0.16.2944-ls299'},
+            'State': {'Status': 'running'},
         }
         with patch.object(updater, '_get_container_config', return_value=container_info), \
              patch.object(updater.docker, 'stop_container') as mock_stop:

--- a/tests/test_registry_override.py
+++ b/tests/test_registry_override.py
@@ -11,7 +11,7 @@ import json
 import pytest
 from unittest.mock import patch, call
 
-from ium import DockerImageUpdater
+from ium import DEFAULT_REQUEST_TIMEOUT, DEFAULT_STOP_TIMEOUT, DockerImageUpdater
 
 
 @pytest.fixture
@@ -116,7 +116,11 @@ class TestUpdateContainersRegistryForwarding:
                 ["homarr"], "homarr-labs/homarr", "v1.9.0", registry="ghcr.io"
             )
 
-        mock_update.assert_called_once_with("homarr", "homarr-labs/homarr", "v1.9.0", "ghcr.io")
+        mock_update.assert_called_once_with(
+            "homarr", "homarr-labs/homarr", "v1.9.0", "ghcr.io",
+            stop_timeout=DEFAULT_STOP_TIMEOUT,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT,
+        )
 
     def test_registry_forwarded_to_every_container(self, ghcr_updater):
         with patch.object(ghcr_updater, "_update_container", return_value=True) as mock_update:
@@ -153,7 +157,9 @@ class TestCheckAndUpdateRegistryFlow:
             ghcr_updater.check_and_update()
 
         mock_update.assert_called_once_with(
-            ["homarr"], "homarr-labs/homarr", "v1.9.0", "ghcr.io"
+            ["homarr"], "homarr-labs/homarr", "v1.9.0", "ghcr.io",
+            stop_timeout=DEFAULT_STOP_TIMEOUT,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT,
         )
 
     def test_failed_update_does_not_save_state(self, ghcr_updater):

--- a/tests/test_rename_failure_recovery.py
+++ b/tests/test_rename_failure_recovery.py
@@ -1,0 +1,143 @@
+"""A failed rename request leaves the container's identity ambiguous.
+
+The rename to <name>_backup_<epoch> happens after the container is stopped but
+before the replacement exists, so it is the most dangerous call in the update to
+get a timeout on:
+
+  * if the daemon applied it late, the container is now the backup and nothing
+    answers to the original name -- later cycles inspect the original, get 404,
+    and give up forever
+  * if the daemon never applied it, the container is stopped under its own name
+    and creating a replacement would collide with it
+
+Neither can be assumed, so both names are inspected before deciding.
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from docker_api import DockerAPIError
+from ium import DockerImageUpdater
+
+
+TARGET_TAG = "v9.11.0-ls414"
+RENAME_TIMED_OUT = DockerAPIError(0, "POST /v1.41/containers/calibre/rename: timed out")
+NOT_FOUND = DockerAPIError(404, "No such container")
+
+
+@pytest.fixture
+def updater(tmp_path):
+    config_file = tmp_path / "config.json"
+    state_file = tmp_path / "state.json"
+    config_file.write_text(json.dumps({
+        "images": [{
+            "image": "linuxserver/calibre",
+            "regex": r"^v[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+            "base_tag": "latest",
+            "auto_update": True,
+        }]
+    }))
+    state_file.write_text("{}")
+    return DockerImageUpdater(str(config_file), str(state_file))
+
+
+def container_info() -> dict:
+    return {
+        "Id": "abc123" * 10,
+        "Config": {
+            "Image": "linuxserver/calibre:v9.10.0-ls400",
+            "Hostname": "abc123abc1",
+            "User": "", "WorkingDir": "",
+            "Env": ["PATH=/usr/bin:/bin"],
+            "Cmd": None, "Labels": {},
+        },
+        "HostConfig": {
+            "RestartPolicy": {"Name": "", "MaximumRetryCount": 0},
+            "NetworkMode": "default",
+            "PortBindings": None,
+            "Privileged": False, "CapAdd": None, "CapDrop": None,
+            "Devices": None, "Memory": 0, "CpuShares": 0,
+            "CpuQuota": 0, "SecurityOpt": None, "Runtime": "",
+        },
+        "Mounts": [],
+        "NetworkSettings": {"Networks": {}},
+        "State": {"Status": "running"},
+    }
+
+
+class TestRenameFailureRecovery:
+
+    def _run(self, updater, inspect_side_effect):
+        """Attempt an update whose rename request fails.
+
+        *inspect_side_effect* answers the post-rename existence probes, which
+        query the backup name first and then the original name.
+        """
+        with patch.object(updater, '_get_container_config',
+                          return_value=container_info()), \
+             patch.object(updater.docker, 'stop_container'), \
+             patch.object(updater.docker, 'rename_container',
+                          side_effect=RENAME_TIMED_OUT) as mock_rename, \
+             patch.object(updater.docker, 'inspect_container',
+                          side_effect=inspect_side_effect), \
+             patch.object(updater.docker, 'create_container',
+                          return_value='new123') as mock_create, \
+             patch.object(updater.docker, 'start_container') as mock_start, \
+             patch.object(updater.docker, 'remove_container'):
+
+            result = updater._update_container(
+                'calibre', 'linuxserver/calibre', TARGET_TAG
+            )
+
+        return result, mock_create, mock_start, mock_rename
+
+    def test_update_continues_when_rename_actually_landed(self, updater):
+        """Backup exists and the original is gone: the rename did happen."""
+        # probe order: backup_name -> exists, container_name -> 404
+        result, mock_create, mock_start, _ = self._run(
+            updater, [container_info(), NOT_FOUND]
+        )
+
+        assert result is True
+        mock_create.assert_called_once()
+
+    def test_original_is_restarted_when_rename_did_not_land(self, updater):
+        """Original still present: abort, but do not leave it stopped."""
+        # probe order: backup_name -> 404, container_name -> exists
+        result, mock_create, mock_start, _ = self._run(
+            updater, [NOT_FOUND, container_info()]
+        )
+
+        assert result is False
+        mock_create.assert_not_called()
+        mock_start.assert_called_once_with('calibre', timeout=60)
+
+    def test_aborts_without_creating_when_state_is_indeterminate(self, updater):
+        """Neither name resolvable: refuse to guess, never create a replacement."""
+        transport_down = DockerAPIError(0, "GET /json: timed out")
+        result, mock_create, mock_start, _ = self._run(
+            updater, [transport_down, transport_down]
+        )
+
+        assert result is False
+        mock_create.assert_not_called()
+        mock_start.assert_not_called()
+
+    def test_does_not_probe_when_rename_succeeds(self, updater):
+        """The existence probes must only run on the failure path."""
+        with patch.object(updater, '_get_container_config',
+                          return_value=container_info()), \
+             patch.object(updater.docker, 'stop_container'), \
+             patch.object(updater.docker, 'rename_container'), \
+             patch.object(updater.docker, 'inspect_container') as mock_inspect, \
+             patch.object(updater.docker, 'create_container', return_value='new123'), \
+             patch.object(updater.docker, 'start_container'), \
+             patch.object(updater.docker, 'remove_container'):
+
+            result = updater._update_container(
+                'calibre', 'linuxserver/calibre', TARGET_TAG
+            )
+
+        assert result is True
+        mock_inspect.assert_not_called()

--- a/tests/test_socket_timeout_rollback.py
+++ b/tests/test_socket_timeout_rollback.py
@@ -1,0 +1,228 @@
+"""Socket-level failures must behave like Docker API errors.
+
+Regression tests for the 2026-07-29 incident: a read timeout on the Docker
+socket escaped as a bare ``TimeoutError``, which no handler caught.  The
+container had already been stopped and renamed to a backup by that point, so
+rollback never ran and the service was left down.
+
+The timeout is injected at ``getresponse()`` — the same place the production
+traceback showed it (``http.client.begin`` -> ``_read_status`` -> socket recv).
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from docker_api import DockerAPIError, DockerClient
+from ium import DockerImageUpdater
+
+
+# ---------------------------------------------------------------------------
+# Fake Docker socket
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status: int, body: bytes = b""):
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _FakeConn:
+    """Stands in for UnixHTTPConnection, driven by a handler callable."""
+
+    def __init__(self, handler, calls):
+        self._handler = handler
+        self._calls = calls
+        self._pending = None
+
+    def request(self, method, url, body=None, headers=None):
+        self._pending = (method, url, body)
+        self._calls.append((method, url))
+
+    def getresponse(self):
+        return self._handler(*self._pending)
+
+    def close(self):
+        pass
+
+
+def fake_socket(handler):
+    """Patch DockerClient's transport.  Returns (patcher, calls list)."""
+    calls: list[tuple[str, str]] = []
+    patcher = patch(
+        "docker_api.UnixHTTPConnection",
+        lambda socket_path, timeout=30: _FakeConn(handler, calls),
+    )
+    return patcher, calls
+
+
+CONTAINER_INFO = {
+    "Id": "abc123" * 10,
+    "Config": {
+        "Image": "linuxserver/sonarr:4.0.0.740-ls290",
+        "Hostname": "abc123abc1",
+        "User": "", "WorkingDir": "",
+        "Env": ["PATH=/usr/bin:/bin"],
+        "Cmd": None, "Labels": {},
+    },
+    "HostConfig": {
+        "RestartPolicy": {"Name": "", "MaximumRetryCount": 0},
+        "NetworkMode": "default",
+        "PortBindings": None,
+        "Privileged": False, "CapAdd": None, "CapDrop": None,
+        "Devices": None, "Memory": 0, "CpuShares": 0,
+        "CpuQuota": 0, "SecurityOpt": None, "Runtime": "",
+    },
+    "Mounts": [],
+    "NetworkSettings": {"Networks": {}},
+    "State": {"Status": "running"},
+}
+
+
+@pytest.fixture
+def updater(tmp_path):
+    config_file = tmp_path / "config.json"
+    state_file = tmp_path / "state.json"
+    config_file.write_text(json.dumps({
+        "images": [{
+            "image": "linuxserver/sonarr",
+            "regex": r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+            "base_tag": "latest",
+            "auto_update": True,
+        }]
+    }))
+    state_file.write_text("{}")
+    return DockerImageUpdater(str(config_file), str(state_file))
+
+
+# ---------------------------------------------------------------------------
+# Transport layer: socket errors must surface as DockerAPIError
+# ---------------------------------------------------------------------------
+
+class TestTransportErrorTranslation:
+    """DockerClient must not leak raw socket exceptions to its callers."""
+
+    def test_read_timeout_raises_docker_api_error(self):
+        def handler(method, url, body):
+            raise TimeoutError("timed out")
+
+        patcher, _ = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            with pytest.raises(DockerAPIError):
+                client.inspect_container("sonarr")
+
+    def test_connection_error_raises_docker_api_error(self):
+        def handler(method, url, body):
+            raise ConnectionRefusedError("connection refused")
+
+        patcher, _ = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            with pytest.raises(DockerAPIError):
+                client.inspect_container("sonarr")
+
+    def test_timeout_message_identifies_the_request(self):
+        """The error must name the failing call so logs are actionable."""
+        def handler(method, url, body):
+            raise TimeoutError("timed out")
+
+        patcher, _ = fake_socket(handler)
+        with patcher:
+            client = DockerClient(socket_path="/nonexistent.sock")
+            with pytest.raises(DockerAPIError) as exc:
+                client.start_container("sonarr")
+            assert "/containers/sonarr/start" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Symptom 1: the stopped container must be restored
+# ---------------------------------------------------------------------------
+
+class TestRollbackOnSocketTimeout:
+    """A timeout after stop+rename must roll the old container back."""
+
+    def _handler_timing_out_on(self, target_fragment):
+        def handler(method, url, body):
+            if method == "GET" and "/containers/sonarr/json" in url:
+                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+            if target_fragment in url:
+                raise TimeoutError("timed out")
+            if method == "POST" and "/containers/create" in url:
+                return _FakeResponse(201, json.dumps({"Id": "new123"}).encode())
+            return _FakeResponse(204)
+        return handler
+
+    def test_create_timeout_restores_old_container(self, updater):
+        patcher, calls = fake_socket(self._handler_timing_out_on("/containers/create"))
+        with patcher:
+            result = updater._update_container(
+                "sonarr", "linuxserver/sonarr", "4.0.16.2944-ls299"
+            )
+
+        assert result is False, "a failed update must report failure, not raise"
+
+        renamed_back = [
+            u for m, u in calls
+            if m == "POST" and "/rename" in u and "name=sonarr" in u and "_backup_" in u
+        ]
+        assert renamed_back, (
+            f"backup was never renamed back to 'sonarr'; calls were: {calls}"
+        )
+
+        restarted = [
+            u for m, u in calls if m == "POST" and u.endswith("/containers/sonarr/start")
+        ]
+        assert restarted, f"old container was never restarted; calls were: {calls}"
+
+    def test_start_timeout_does_not_leave_container_stopped(self, updater):
+        patcher, calls = fake_socket(self._handler_timing_out_on("/start"))
+        with patcher:
+            result = updater._update_container(
+                "sonarr", "linuxserver/sonarr", "4.0.16.2944-ls299"
+            )
+
+        assert result is False
+        renamed_back = [
+            u for m, u in calls
+            if m == "POST" and "/rename" in u and "name=sonarr" in u and "_backup_" in u
+        ]
+        assert renamed_back, (
+            f"backup was never renamed back after start timeout; calls were: {calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Symptom 2: one timeout must not abort the rest of the cycle
+# ---------------------------------------------------------------------------
+
+class TestUpdateLoopSurvivesTimeout:
+    """A timeout on one container must not skip the containers after it."""
+
+    def test_second_container_still_updated_after_first_times_out(self, updater):
+        def handler(method, url, body):
+            if method == "GET" and "/containers/sonarr-hd/json" in url:
+                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+            if method == "GET" and "/containers/sonarr-4k/json" in url:
+                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+            # Only the first container's create times out.
+            if "/containers/create" in url and "name=sonarr-hd" in url:
+                raise TimeoutError("timed out")
+            if method == "POST" and "/containers/create" in url:
+                return _FakeResponse(201, json.dumps({"Id": "new123"}).encode())
+            return _FakeResponse(204)
+
+        patcher, calls = fake_socket(handler)
+        with patcher:
+            results = updater._update_containers(
+                ["sonarr-hd", "sonarr-4k"], "linuxserver/sonarr", "4.0.16.2944-ls299"
+            )
+
+        assert set(results) == {"sonarr-hd", "sonarr-4k"}, (
+            f"loop aborted early; only got {set(results)}"
+        )
+        assert results["sonarr-hd"] is False
+        assert results["sonarr-4k"] is True

--- a/tests/test_socket_timeout_rollback.py
+++ b/tests/test_socket_timeout_rollback.py
@@ -11,52 +11,10 @@ traceback showed it (``http.client.begin`` -> ``_read_status`` -> socket recv).
 
 import json
 import pytest
-from unittest.mock import patch
 
 from docker_api import DockerAPIError, DockerClient
 from ium import DockerImageUpdater
-
-
-# ---------------------------------------------------------------------------
-# Fake Docker socket
-# ---------------------------------------------------------------------------
-
-class _FakeResponse:
-    def __init__(self, status: int, body: bytes = b""):
-        self.status = status
-        self._body = body
-
-    def read(self) -> bytes:
-        return self._body
-
-
-class _FakeConn:
-    """Stands in for UnixHTTPConnection, driven by a handler callable."""
-
-    def __init__(self, handler, calls):
-        self._handler = handler
-        self._calls = calls
-        self._pending = None
-
-    def request(self, method, url, body=None, headers=None):
-        self._pending = (method, url, body)
-        self._calls.append((method, url))
-
-    def getresponse(self):
-        return self._handler(*self._pending)
-
-    def close(self):
-        pass
-
-
-def fake_socket(handler):
-    """Patch DockerClient's transport.  Returns (patcher, calls list)."""
-    calls: list[tuple[str, str]] = []
-    patcher = patch(
-        "docker_api.UnixHTTPConnection",
-        lambda socket_path, timeout=30: _FakeConn(handler, calls),
-    )
-    return patcher, calls
+from tests.fake_docker import FakeResponse, fake_socket
 
 
 CONTAINER_INFO = {
@@ -148,12 +106,12 @@ class TestRollbackOnSocketTimeout:
     def _handler_timing_out_on(self, target_fragment):
         def handler(method, url, body):
             if method == "GET" and "/containers/sonarr/json" in url:
-                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+                return FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
             if target_fragment in url:
                 raise TimeoutError("timed out")
             if method == "POST" and "/containers/create" in url:
-                return _FakeResponse(201, json.dumps({"Id": "new123"}).encode())
-            return _FakeResponse(204)
+                return FakeResponse(201, json.dumps({"Id": "new123"}).encode())
+            return FakeResponse(204)
         return handler
 
     def test_create_timeout_restores_old_container(self, updater):
@@ -205,15 +163,15 @@ class TestUpdateLoopSurvivesTimeout:
     def test_second_container_still_updated_after_first_times_out(self, updater):
         def handler(method, url, body):
             if method == "GET" and "/containers/sonarr-hd/json" in url:
-                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+                return FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
             if method == "GET" and "/containers/sonarr-4k/json" in url:
-                return _FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
+                return FakeResponse(200, json.dumps(CONTAINER_INFO).encode())
             # Only the first container's create times out.
             if "/containers/create" in url and "name=sonarr-hd" in url:
                 raise TimeoutError("timed out")
             if method == "POST" and "/containers/create" in url:
-                return _FakeResponse(201, json.dumps({"Id": "new123"}).encode())
-            return _FakeResponse(204)
+                return FakeResponse(201, json.dumps({"Id": "new123"}).encode())
+            return FakeResponse(204)
 
         patcher, calls = fake_socket(handler)
         with patcher:

--- a/tests/test_stop_failure_recovery.py
+++ b/tests/test_stop_failure_recovery.py
@@ -1,0 +1,136 @@
+"""A failed stop request does not mean the container is still running.
+
+In the 2026-07-29 incident the stop request for a heavy container exceeded its
+socket budget (43s against a 40s deadline), but the daemon went on to stop the
+container anyway.  Abandoning the update on the failed request left the
+container down until the next cycle, so before giving up we inspect the actual
+state: if the container really is stopped, the update can proceed.
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from docker_api import DockerAPIError
+from ium import DockerImageUpdater
+
+
+TARGET_TAG = "v9.11.0-ls414"
+STOP_TIMED_OUT = DockerAPIError(0, "POST /v1.41/containers/calibre/stop: timed out")
+
+
+@pytest.fixture
+def updater(tmp_path):
+    config_file = tmp_path / "config.json"
+    state_file = tmp_path / "state.json"
+    config_file.write_text(json.dumps({
+        "images": [{
+            "image": "linuxserver/calibre",
+            "regex": r"^v[0-9]+\.[0-9]+\.[0-9]+-ls[0-9]+$",
+            "base_tag": "latest",
+            "auto_update": True,
+        }]
+    }))
+    state_file.write_text("{}")
+    return DockerImageUpdater(str(config_file), str(state_file))
+
+
+def running_info(status: str = "running") -> dict:
+    return {
+        "Id": "abc123" * 10,
+        "Config": {
+            "Image": "linuxserver/calibre:v9.10.0-ls400",
+            "Hostname": "abc123abc1",
+            "User": "", "WorkingDir": "",
+            "Env": ["PATH=/usr/bin:/bin"],
+            "Cmd": None, "Labels": {},
+        },
+        "HostConfig": {
+            "RestartPolicy": {"Name": "", "MaximumRetryCount": 0},
+            "NetworkMode": "default",
+            "PortBindings": None,
+            "Privileged": False, "CapAdd": None, "CapDrop": None,
+            "Devices": None, "Memory": 0, "CpuShares": 0,
+            "CpuQuota": 0, "SecurityOpt": None, "Runtime": "",
+        },
+        "Mounts": [],
+        "NetworkSettings": {"Networks": {}},
+        "State": {"Status": status},
+    }
+
+
+class TestStopFailureRecovery:
+
+    def _run(self, updater, post_stop_state):
+        """Attempt an update where the stop request fails.
+
+        *post_stop_state* is what inspecting the container afterwards returns.
+        """
+        with patch.object(updater, '_get_container_config',
+                          side_effect=[running_info(), post_stop_state]), \
+             patch.object(updater.docker, 'stop_container',
+                          side_effect=STOP_TIMED_OUT), \
+             patch.object(updater.docker, 'rename_container') as mock_rename, \
+             patch.object(updater.docker, 'create_container',
+                          return_value='new123') as mock_create, \
+             patch.object(updater.docker, 'start_container'), \
+             patch.object(updater.docker, 'remove_container'):
+
+            result = updater._update_container(
+                'calibre', 'linuxserver/calibre', TARGET_TAG
+            )
+
+        return result, mock_rename, mock_create
+
+    def test_update_proceeds_when_container_did_stop(self, updater):
+        """The daemon finished the stop late — carry on with the update."""
+        result, mock_rename, mock_create = self._run(updater, running_info('exited'))
+
+        assert result is True
+        mock_rename.assert_called_once()
+        mock_create.assert_called_once()
+
+    def test_update_proceeds_when_container_is_dead(self, updater):
+        result, mock_rename, _ = self._run(updater, running_info('dead'))
+
+        assert result is True
+        mock_rename.assert_called_once()
+
+    def test_update_aborts_when_container_still_running(self, updater):
+        """Renaming a live container would be destructive — refuse."""
+        result, mock_rename, mock_create = self._run(updater, running_info('running'))
+
+        assert result is False
+        mock_rename.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_update_aborts_when_container_is_paused(self, updater):
+        """'paused' is not stopped; treat it as still running."""
+        result, mock_rename, _ = self._run(updater, running_info('paused'))
+
+        assert result is False
+        mock_rename.assert_not_called()
+
+    def test_update_aborts_when_state_cannot_be_determined(self, updater):
+        """If the follow-up inspect also fails, do not guess."""
+        result, mock_rename, _ = self._run(updater, None)
+
+        assert result is False
+        mock_rename.assert_not_called()
+
+    def test_successful_stop_does_not_inspect_again(self, updater):
+        """The extra inspect must only happen on the failure path."""
+        with patch.object(updater, '_get_container_config',
+                          side_effect=[running_info()]) as mock_inspect, \
+             patch.object(updater.docker, 'stop_container'), \
+             patch.object(updater.docker, 'rename_container'), \
+             patch.object(updater.docker, 'create_container', return_value='new123'), \
+             patch.object(updater.docker, 'start_container'), \
+             patch.object(updater.docker, 'remove_container'):
+
+            result = updater._update_container(
+                'calibre', 'linuxserver/calibre', TARGET_TAG
+            )
+
+        assert result is True
+        assert mock_inspect.call_count == 1


### PR DESCRIPTION
## Why

Two independent problems, both making container updates fail:

1. **Issue #25 — ium is broken on modern Docker.** `API_VERSION` was pinned to `v1.41`, but Docker Engine 25+ rejects anything below its `MinAPIVersion` of 1.44. Every request 400s, so container discovery returns nothing and updates are reported against `unknown`.
2. **A socket timeout could strand a container permanently.** Diagnosed from a production `log.db`: on 2026-07-29 the stop request for a heavy container exceeded its 40 s socket budget (43 s elapsed), the bare `TimeoutError` escaped every handler, and the container was left stopped.

## Root cause of (2)

`_request` let socket errors escape as bare `OSError`/`TimeoutError`. Every caller catches only `DockerAPIError`, so the timeout slipped past both the rollback handler and the outer handler in `_update_container` — and past the per-image loop, aborting the rest of the check cycle.

The production traceback:

```
webui.py:219 run_check → ium.py:1533 check_and_update → ium.py:1184 _update_containers
  → ium.py:1113 _update_container → self.docker.stop_container(container_name)
  → docker_api.py:184  timeout=timeout + 30
  → TimeoutError: timed out
```

## Changes

| Commit | |
|---|---|
| `d4fcec8` | Restore `AGENTS.md → CLAUDE.md` symlink |
| `7e6ebc9` | **Root fix:** translate socket errors into `DockerAPIError`, so rollback is reachable and one failure no longer aborts the cycle |
| `f645dfd` | Start a container that a previous run created but never started (was reported as "already running") |
| `4e9d7a8` | Per-image `stop_timeout` / `request_timeout`, plumbed to the Docker client |
| `13af105` | **Negotiate the API version** (fixes #25); rename `REQUEST_TIMEOUT` → `REGISTRY_REQUEST_TIMEOUT` |
| `a6c6b1c` | On a failed stop, inspect state and continue if the container really did stop |
| `4cce472` | Bump to 1.4.0 |

### API version negotiation

Bumping the pin would break Docker 20.10 (ceiling 1.41), so no single pin works. The client now probes unversioned `GET /version` once, prefers `API_VERSION`, raises to the daemon's `MinAPIVersion` when higher and lowers to its `ApiVersion` when lower. Probe failure or an unparseable response falls back to the pin.

### Timeouts

| Key | Default | Meaning |
|-----|---------|---------|
| `stop_timeout` | `10` | SIGTERM grace period (Docker's `t`) |
| `request_timeout` | `60` | Socket read budget for lifecycle calls |

`stop_container` now separates the two, so the socket gets `stop_timeout + request_timeout` and cannot expire before the grace period has elapsed. The stop budget goes from 40 s to 70 s by default.

### Timeouts are no longer treated as failures

A timeout means *unknown outcome*, not *failed*. ium now inspects and recovers: continue if the stop actually landed, restore the previous container if a later step failed, start a container created but never started.

## Testing

**436 passed**, 20 live deselected (was 396 before this branch). Every fix was driven by a failing test first, including a fake Docker socket (`tests/fake_docker.py`) that injects the timeout at `getresponse()` — the exact frame from the production traceback — so the real `_request` and rollback paths execute.

Four new test modules: socket-error translation and rollback, interrupted-update recovery, configurable timeouts, stop-failure recovery, API version negotiation.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic compatibility with different Docker Engine API versions.
  - Added configurable container stop and request timeouts.
  - Improved recovery for interrupted or partially completed container updates.
  - Automatically starts containers found stopped on the target image.

- **Bug Fixes**
  - Docker connection failures now produce consistent, actionable errors.
  - Timed-out updates safely restore containers and continue processing other containers.

- **Documentation**
  - Documented timeout settings, defaults, and runtime behavior.

- **Tests**
  - Added coverage for API compatibility, timeout handling, recovery, and multi-container updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->